### PR TITLE
Fixes on monitors collision

### DIFF
--- a/objects/obj_monitor/Step_1.gml
+++ b/objects/obj_monitor/Step_1.gml
@@ -76,6 +76,16 @@
 		//Flip it back
 		image_yscale = 1;
 	}
+	//Check if monitor is not colliding the ground anymore
+	if (ground)
+	{
+	if (!collision_instance(0, 1, 0, true, true))
+		{
+		// Floor is gone, make it fall again
+		ground = false;
+		y_speed = 0.1;
+		}
+	}
 	if(!ground)
 	{
 		//Update position by speed


### PR DESCRIPTION
Fixed monitor collision when placed on top of an object that gets destroyed or falls (e.g., crumbling platform).