### PR TITLE
Waterpools

### DIFF
--- a/Harmony Framework.yyp
+++ b/Harmony Framework.yyp
@@ -264,6 +264,7 @@
     {"id":{"name":"obj_titlecard","path":"objects/obj_titlecard/obj_titlecard.yy",},},
     {"id":{"name":"obj_water_effect","path":"objects/obj_water_effect/obj_water_effect.yy",},},
     {"id":{"name":"obj_water","path":"objects/obj_water/obj_water.yy",},},
+    {"id":{"name":"obj_waterpool","path":"objects/obj_waterpool/obj_waterpool.yy",},},
     {"id":{"name":"obj_window","path":"objects/obj_window/obj_window.yy",},},
     {"id":{"name":"par_background","path":"objects/par_background/par_background.yy",},},
     {"id":{"name":"par_breakable_floor","path":"objects/par_breakable_floor/par_breakable_floor.yy",},},

--- a/objects/obj_bubble/Step_0.gml
+++ b/objects/obj_bubble/Step_0.gml
@@ -1,7 +1,8 @@
 /// @description Script
 	sprite_index = asset_get_index("spr_bubble_" + string(type+1)); 
 	
-	var water = collision_point(x, bbox_top, obj_water, true, true);
+	//Water check
+	var waterpool = instance_collide_waterpool(, sprite_get_bbox_top(sprite_index) - sprite_get_yoffset(sprite_index));
 	
 	//Movement
 	y -= 0.5;
@@ -11,7 +12,7 @@
 	angle = (angle + 2) mod 360;
 	
 	//Destroy outside of window or above water horizon
-	if(!on_screen() || water == noone)
+	if(!on_screen() || (instance_exists(obj_water) && waterpool == noone ? bbox_top < obj_water.y : waterpool == noone))
 	{
 		instance_destroy();
 		exit;

--- a/objects/obj_bubble/Step_0.gml
+++ b/objects/obj_bubble/Step_0.gml
@@ -1,6 +1,7 @@
 /// @description Script
-	exit;
 	sprite_index = asset_get_index("spr_bubble_" + string(type+1)); 
+	
+	var waterpool = collision_point(x, y, obj_waterpool, true, false);
 	
 	//Movement
 	y -= 0.5;
@@ -10,7 +11,11 @@
 	angle = (angle + 2) mod 360;
 	
 	//Destroy outside of window or above water horizon
-	if(!on_screen() || bbox_top < obj_water.y) instance_destroy();
+	if(!on_screen() || (instance_exists(obj_water) ? bbox_top < obj_water.y : waterpool == noone))
+	{
+		instance_destroy();
+		exit;
+	}
 	
 	//Utilize animation system
 	if(image_index >= image_number-1)

--- a/objects/obj_bubble/Step_0.gml
+++ b/objects/obj_bubble/Step_0.gml
@@ -1,7 +1,7 @@
 /// @description Script
 	sprite_index = asset_get_index("spr_bubble_" + string(type+1)); 
 	
-	var waterpool = collision_point(x, y, obj_waterpool, true, false);
+	var water = collision_point(x, bbox_top, obj_water, true, true);
 	
 	//Movement
 	y -= 0.5;
@@ -11,7 +11,7 @@
 	angle = (angle + 2) mod 360;
 	
 	//Destroy outside of window or above water horizon
-	if(!on_screen() || (instance_exists(obj_water) ? bbox_top < obj_water.y : waterpool == noone))
+	if(!on_screen() || water == noone)
 	{
 		instance_destroy();
 		exit;

--- a/objects/obj_water/Create_0.gml
+++ b/objects/obj_water/Create_0.gml
@@ -1,8 +1,0 @@
-/// @description Values
-	spr_width = sprite_get_width(sprite_index);
-	screen_width = (global.window_width)/sprite_get_width(sprite_index);
-	surf = surface_create(global.window_width, global.window_height);
-	surf_bg = surface_create(global.window_width, global.window_height);
-	
-	//Change animation speed
-	anim_speed = 0.15;

--- a/objects/obj_water/Draw_0.gml
+++ b/objects/obj_water/Draw_0.gml
@@ -1,46 +1,6 @@
 /// @description Draw water 
-
 	//Camera position
-	var cx, cy, sw, sh;
-	cx = camera_get_view_x(view_camera[view_current])-64;
-	cy = camera_get_view_y(view_camera[view_current])
-	sw = global.window_width;
-	sh = global.window_height;
-	
-	//Set x position to the left side of the screen
-	x = cx;
-	
-	//Draw basic rectangle with blendmode
-	draw_set_color($5b301e);
-	gpu_set_blendmode(bm_subtract);
-	draw_rectangle(cx, max(y, cy), cx+sw+64, max(y, cy)+sh, false);
-	gpu_set_blendmode(bm_normal);
-	draw_set_color(c_white);
-	
-	//IMPORTANT NOTE!!
-	//Enable this code if you wanna use shaders for color replacing instead of blend modes
-	//You can either use palette_swap or set_color_grading
-	
-	/*
-	//Draw whole ass water
-	if(!surface_exists(surf)) surf = surface_create(global.window_width, global.window_height);
-	
-	//Draw shit in this
-	surface_set_target(surf);
-	
-	//Draw tint surface
-	gpu_set_blendenable(false);
-	surface_copy(surf, 0, 0, application_surface);
-	set_color_grading(yourlut, 17);
+	var cx = camera_get_view_x(view_camera[view_current]);
 
-	//Done
-	surface_reset_target();
-
-	//Draw surface
-	draw_surface_part(surf, 0,y-cy,426,cy,cx+64, y);
-	shader_reset();
-	gpu_set_blendenable(true);
-	*/
-	//Draw the water horizon
-	for(var i = 0; i < screen_width + 2; i++)
-		draw_sprite(sprite_index, FRAME_TIMER * anim_speed, (round(cx/spr_width)*spr_width)+spr_width*i, y);
+	//Draw the water
+	water_draw(cx, y, room_width, room_height - y);

--- a/objects/obj_water/Draw_0.gml
+++ b/objects/obj_water/Draw_0.gml
@@ -1,6 +1,3 @@
-/// @description Draw water 
-	//Camera position
-	var cx = camera_get_view_x(view_camera[view_current]);
-
+/// @description Draw water
 	//Draw the water
-	water_draw(cx, y, room_width, room_height - y);
+	water_draw(0, y, room_width, room_height - y);

--- a/objects/obj_waterpool/Draw_0.gml
+++ b/objects/obj_waterpool/Draw_0.gml
@@ -1,0 +1,2 @@
+/// @description Draw water
+	water_draw(x, y, sprite_width, sprite_height);

--- a/objects/obj_waterpool/Step_0.gml
+++ b/objects/obj_waterpool/Step_0.gml
@@ -1,0 +1,16 @@
+/// @description Script
+	var player = player_find(0),
+		collision = player_collide_object();
+	
+	with(player)
+	{
+		if(!collision_rectangle(x - wall_w, y - hitbox_h, x + wall_w, y + hitbox_h, obj_waterpool, true, false))
+		{
+			player_set_underwater(false, obj_waterpool);
+		}
+		
+		if(collision)
+		{
+			player_set_underwater(true, other.id);
+		}
+	}

--- a/objects/obj_waterpool/Step_0.gml
+++ b/objects/obj_waterpool/Step_0.gml
@@ -1,16 +1,19 @@
 /// @description Script
 	var player = player_find(0),
-		collision = player_collide_object();
+		waterCheck = (instance_exists(obj_water) ? player.y < obj_water.y : true);
 	
+	//In the player object
 	with(player)
 	{
-		if(!collision_rectangle(x - wall_w, y - hitbox_h, x + wall_w, y + hitbox_h, obj_waterpool, true, false))
+		//If you're colliding with a water pool
+		if(player_collide_waterpool())
 		{
-			player_set_underwater(false, obj_waterpool);
-		}
-		
-		if(collision)
-		{
+			//Set the flag to true
 			player_set_underwater(true, other.id);
+		}
+		else
+		{
+			//If you're above the water level object, set the flag to false
+			if(waterCheck) player_set_underwater(false, obj_waterpool);
 		}
 	}

--- a/objects/obj_waterpool/Step_0.gml
+++ b/objects/obj_waterpool/Step_0.gml
@@ -6,7 +6,7 @@
 	with(player)
 	{
 		//If you're colliding with a water pool
-		if(player_collide_waterpool())
+		if(instance_collide_waterpool())
 		{
 			//Set the flag to true
 			player_set_underwater(true, other.id);

--- a/objects/obj_waterpool/obj_waterpool.yy
+++ b/objects/obj_waterpool/obj_waterpool.yy
@@ -1,11 +1,12 @@
 {
   "$GMObject":"",
-  "%Name":"obj_water",
+  "%Name":"obj_waterpool",
   "eventList":[
+    {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":3,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":8,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
   ],
   "managed":true,
-  "name":"obj_water",
+  "name":"obj_waterpool",
   "overriddenProperties":[],
   "parent":{
     "name":"Water",
@@ -30,8 +31,8 @@
   "resourceVersion":"2.0",
   "solid":false,
   "spriteId":{
-    "name":"spr_water",
-    "path":"sprites/spr_water/spr_water.yy",
+    "name":"spr_trigger",
+    "path":"sprites/spr_trigger/spr_trigger.yy",
   },
   "spriteMaskId":null,
   "visible":true,

--- a/scripts/player_water/player_water.gml
+++ b/scripts/player_water/player_water.gml
@@ -178,32 +178,22 @@ function player_set_underwater(value, object = obj_water)
 	{
 		//Speed up the player
 		y_speed *= 1.25;
-		
-		//Execute this only if the collision happens at the top
-		if(side == C_TOP)
-		{
-			//Create effects
-			create_effect(x, object.y, spr_water_splash, 0.35);
-			
-			//Play sound
-			play_sound(sfx_water_splash);
-		}
 	}
 	else
 	{		
 		//Slow down the player
 		x_speed *= 0.5;
 		y_speed *= 0.25;
-		
-		//Execute this only if the collision happens at the top
-		if(side == C_TOP)
-		{
-			//Create effects
-			create_effect(x, object.y, spr_water_splash, 0.35);
+	}
+	
+	//Execute this only if the collision happens at the top
+	if(side == C_TOP)
+	{
+		//Create effect
+		create_effect(x, object.y, spr_water_splash, 0.35);
 			
-			//Play sound
-			play_sound(sfx_water_splash);
-		}
+		//Play sound
+		play_sound(sfx_water_splash);
 	}
 	
 	//Trigger the flag

--- a/scripts/player_water/player_water.gml
+++ b/scripts/player_water/player_water.gml
@@ -4,12 +4,20 @@ function player_water()
 	water_run = false;
 	
 	//Stop executing if theres no water
-	if(!instance_exists(obj_water) || !collision_allow) exit;
-	
+	if(!instance_exists(obj_water) && !instance_exists(obj_waterpool) || !collision_allow) exit;
+
 	// Constants 
-	var waterY = obj_water.y;
+	var waterY = (instance_exists(obj_water) ? obj_water.y : 0);
 	var waterRange = 8;
 	var waterSpd = 4;
+	var waterPool = collision_point(x, y + hitbox_h + waterRange, obj_waterpool, true, false);
+	
+	// Check for water pools below you
+	if(waterPool)
+	{
+		// Change the constant to the found waterpool's Y
+		waterY = waterPool.y;
+	}
 	
 	// Is player's bottom side in the water's range?
 	if(y + hitbox_h > waterY - waterRange && y + hitbox_h < waterY + waterRange && ground
@@ -25,7 +33,7 @@ function player_water()
 			if(FRAME_TIMER mod 4 == 0 && global.water_running_effect == 1)
 			{
 				//Create effects
-				create_effect(obj_player.x, obj_water.y, spr_water_splash, 0.35, obj_player.depth - 1);
+				create_effect(obj_player.x, waterY, spr_water_splash, 0.35, obj_player.depth - 1);
 				play_sound(sfx_water_splash);	
 			}
 		}
@@ -42,46 +50,21 @@ function player_water()
 	if(!water_run || on_terrain)
 		audio_stop_sound(sfx_water_run);
 	
-	
-	//Entering water
-	if(y >= obj_water.y)
+	if(instance_exists(obj_water))
 	{
-		//Player hitting the water
-		if(!underwater)
+		//Entering water
+		if(y >= obj_water.y)
 		{
-			//Slow down the player
-			x_speed *= 0.5;
-			y_speed *= 0.25;
-			
-			//Create effects
-			create_effect(x, obj_water.y, spr_water_splash, 0.35);
-			
-			//Play sound
-			play_sound(sfx_water_splash);
+			//Player hitting the water
+			player_set_underwater(true);
 		}
-		
-		//Trigger the flag
-		underwater = true;
-	}
 	
-	//Exiting water
-	if(y < obj_water.y)
-	{
-		//Player hitting the water
-		if(underwater)
+		//Exiting water
+		if(y < obj_water.y)
 		{
-			//Speed up the player
-			y_speed *= 1.25;
-			
-			//Create effects
-			create_effect(x, obj_water.y, spr_water_splash, 0.35);
-			
-			//Play sound
-			play_sound(sfx_water_splash);
+			//Player hitting the water
+			player_set_underwater(false);
 		}
-		
-		//Trigger the flag
-		underwater = false;
 	}
 	
 	//Aquaphobia
@@ -122,7 +105,8 @@ function player_water()
 			audio_sound_gain(jing, global.bgm_volume, 0);
 		}
 		
-	}else
+	}
+	else
 	{
 		air = 0;
 	}
@@ -130,7 +114,8 @@ function player_water()
 	if(air < 20*60) audio_stop_sound(j_drowning);
 	
 	//Drown!
-	if(air > 32*60 && knockout_type != K_DROWN){
+	if(air > 32*60 && knockout_type != K_DROWN)
+	{
 		play_sound(sfx_drown);
 		obj_camera.mode = 99;
 		state = player_state_knockout;
@@ -138,6 +123,7 @@ function player_water()
 		x_speed = 0
 		y_speed = 0
 	}
+	
 	//Create the countdown
 	switch(air){
 		case 20*60:
@@ -176,4 +162,50 @@ function player_water()
 			drown_bubble.angle = facing == -1 ? 180 : 0;
 			break;	
 	}
+}
+
+function player_set_underwater(value, object = obj_water)
+{
+	//If the underwater flag is the same, no need to run this again
+	if(underwater == value) exit;
+	
+	//Retrieve collision side
+	var side;
+	with(object) side = player_collide_object();
+	
+	//Player hitting the water
+	if(!value)
+	{
+		//Speed up the player
+		y_speed *= 1.25;
+		
+		//Execute this only if the collision happens at the top
+		if(side == C_TOP)
+		{
+			//Create effects
+			create_effect(x, object.y, spr_water_splash, 0.35);
+			
+			//Play sound
+			play_sound(sfx_water_splash);
+		}
+	}
+	else
+	{		
+		//Slow down the player
+		x_speed *= 0.5;
+		y_speed *= 0.25;
+		
+		//Execute this only if the collision happens at the top
+		if(side == C_TOP)
+		{
+			//Create effects
+			create_effect(x, object.y, spr_water_splash, 0.35);
+			
+			//Play sound
+			play_sound(sfx_water_splash);
+		}
+	}
+	
+	//Trigger the flag
+	underwater = value;
 }

--- a/scripts/player_water/player_water.gml
+++ b/scripts/player_water/player_water.gml
@@ -10,7 +10,7 @@ function player_water()
 	var waterY = (instance_exists(obj_water) ? obj_water.y : 0);
 	var waterRange = 8;
 	var waterSpd = 4;
-	var waterPool = collision_point(x, y + hitbox_h + waterRange, obj_waterpool, true, false);
+	var waterPool = player_collide_waterpool(, waterRange + hitbox_h);
 	
 	// Check for water pools below you
 	if(waterPool)
@@ -49,43 +49,40 @@ function player_water()
 	// Stop the water run sound
 	if(!water_run || on_terrain)
 		audio_stop_sound(sfx_water_run);
-	
-	if(instance_exists(obj_water))
+		
+	//If you aren't colliding with a water pool and you're below the water level
+	if(!player_collide_waterpool() && y >= obj_water.y)
 	{
-		//Entering water
-		if(y >= obj_water.y)
-		{
-			//Player hitting the water
-			player_set_underwater(true);
-		}
-	
-		//Exiting water
-		if(y < obj_water.y)
-		{
-			//Player hitting the water
-			player_set_underwater(false);
-		}
+		//Set the flag to true
+		player_set_underwater(true);
 	}
 	
 	//Aquaphobia
 	if(underwater)
 	{
-		if (shield != S_BUBBLE) {
+		if (shield != S_BUBBLE) 
+		{
 			//bubbles
-			if (bubble_delay > 0 && (air mod bubble_delay == 0)){
+			if (bubble_delay > 0 && (air mod bubble_delay == 0))
+			{
 				bubble_delay = 0
 				var bubble = instance_create_depth(x+6*facing, y-4, depth-1, obj_bubble);
 				bubble.type = 0;	
 				bubble.angle = facing == -1 ? 180 : 0;
 			}
 		
-			if(air mod 60 == 0 ){
+			if(air mod 60 == 0 )
+			{
 				var rand = round(random(1));
 				show_debug_message(rand);
-				if (rand == 0){
+				
+				if(rand == 0)
+				{
 					bubble_delay = irandom_range(6,16)*2
 				}
-				if (air < 20*60) {
+				
+				if (air < 20*60) 
+				{
 					var bubble = instance_create_depth(x+6*facing, y-4, depth-1, obj_bubble);
 					bubble.type = 0;	
 					bubble.angle = facing == -1 ? 180 : 0;
@@ -93,6 +90,7 @@ function player_water()
 			
 			}
 		}
+		
 		//Add air timer
 		air += 1;
 			
@@ -100,7 +98,8 @@ function player_water()
 		if(air == 6*60 || air == 12*60 || air == 18*60) play_sound(sfx_air_warning);
 			
 		//Uh oh drowning music
-		if(!audio_is_playing(j_drowning) && air == 20 * 60){
+		if(!audio_is_playing(j_drowning) && air == 20 * 60)
+		{
 			var jing = audio_play_sound(j_drowning, 0, false);
 			audio_sound_gain(jing, global.bgm_volume, 0);
 		}
@@ -186,8 +185,9 @@ function player_set_underwater(value, object = obj_water)
 		y_speed *= 0.25;
 	}
 	
-	//Execute this only if the collision happens at the top
-	if(side == C_TOP)
+	//Execute this only if the collision happens at the top 
+	//Or the object is the water level and you're below it
+	if(side == C_TOP || object == obj_water && y >= object.y)
 	{
 		//Create effect
 		create_effect(x, object.y, spr_water_splash, 0.35);
@@ -198,4 +198,13 @@ function player_set_underwater(value, object = obj_water)
 	
 	//Trigger the flag
 	underwater = value;
+}
+
+function player_collide_waterpool(offset_x = 0, offset_y = 0)
+{
+	//If you don't allow collisions, return none
+	if(!collision_allow) return noone;
+	
+	//Return this
+	return collision_point(x + offset_x, y + offset_y, obj_waterpool, true, true);
 }

--- a/scripts/player_water/player_water.gml
+++ b/scripts/player_water/player_water.gml
@@ -10,7 +10,7 @@ function player_water()
 	var waterY = (instance_exists(obj_water) ? obj_water.y : 0);
 	var waterRange = 8;
 	var waterSpd = 4;
-	var waterPool = player_collide_waterpool(, waterRange + hitbox_h);
+	var waterPool = instance_collide_waterpool(, waterRange + hitbox_h);
 	
 	// Check for water pools below you
 	if(waterPool)
@@ -51,7 +51,7 @@ function player_water()
 		audio_stop_sound(sfx_water_run);
 		
 	//If you aren't colliding with a water pool and you're below the water level
-	if(!player_collide_waterpool() && y >= obj_water.y)
+	if(!instance_collide_waterpool() && y >= obj_water.y)
 	{
 		//Set the flag to true
 		player_set_underwater(true);
@@ -165,8 +165,8 @@ function player_water()
 
 function player_set_underwater(value, object = obj_water)
 {
-	//If the underwater flag is the same, no need to run this again
-	if(underwater == value) exit;
+	//If the underwater flag is the same or you don't allow collisions, no need to run this again
+	if(underwater == value || !collision_allow) exit;
 	
 	//Retrieve collision side
 	var side;
@@ -200,11 +200,8 @@ function player_set_underwater(value, object = obj_water)
 	underwater = value;
 }
 
-function player_collide_waterpool(offset_x = 0, offset_y = 0)
+function instance_collide_waterpool(offset_x = 0, offset_y = 0)
 {
-	//If you don't allow collisions, return none
-	if(!collision_allow) return noone;
-	
 	//Return this
 	return collision_point(x + offset_x, y + offset_y, obj_waterpool, true, true);
 }

--- a/scripts/render_util/render_util.gml
+++ b/scripts/render_util/render_util.gml
@@ -215,8 +215,6 @@ function draw_state_restore()
 
 function water_draw(x, y, w, h, color = $5b301e, anim_speed = 0.15, sprite = spr_water)
 {
-	var spr_width = sprite_get_width(sprite);
-	
 	//Draw basic rectangle with blendmode
 	draw_set_color(color);
 	gpu_set_blendmode(bm_subtract);
@@ -249,8 +247,5 @@ function water_draw(x, y, w, h, color = $5b301e, anim_speed = 0.15, sprite = spr
 	*/
 	
 	//Draw the water horizon
-	for(var i = 0; i < w/spr_width; i++)
-	{
-		draw_sprite(sprite, FRAME_TIMER * anim_speed, (round(x/spr_width) * spr_width) + spr_width * i, y);
-	}
+	draw_sprite_stretched(sprite, FRAME_TIMER * anim_speed, x, y - sprite_get_yoffset(sprite), w, sprite_get_height(sprite));
 }

--- a/scripts/render_util/render_util.gml
+++ b/scripts/render_util/render_util.gml
@@ -212,3 +212,45 @@ function draw_state_restore()
     matrix_set(matrix_view, _state.matrix_view);
     matrix_set(matrix_projection, _state.matrix_projection);
 }
+
+function water_draw(x, y, w, h, color = $5b301e, anim_speed = 0.15, sprite = spr_water)
+{
+	var spr_width = sprite_get_width(sprite);
+	
+	//Draw basic rectangle with blendmode
+	draw_set_color(color);
+	gpu_set_blendmode(bm_subtract);
+	draw_rectangle(x, y, x + w - 1, y + h - 1, false);
+	gpu_set_blendmode(bm_normal);
+	draw_set_color(c_white);
+	
+	//IMPORTANT NOTE!!
+	//Enable this code if you wanna use shaders for color replacing instead of blend modes
+	//You can either use palette_swap or set_color_grading
+	/*
+	//Draw whole ass water
+	if(!surface_exists(surf)) surf = surface_create(global.window_width, global.window_height);
+	
+	//Draw shit in this
+	surface_set_target(surf);
+	
+	//Draw tint surface
+	gpu_set_blendenable(false);
+	surface_copy(surf, 0, 0, application_surface);
+	set_color_grading(yourlut, 17);
+
+	//Done
+	surface_reset_target();
+
+	//Draw surface
+	draw_surface_part(surf, 0, 0, w, h, x, y);
+	shader_reset();
+	gpu_set_blendenable(true);
+	*/
+	
+	//Draw the water horizon
+	for(var i = 0; i < w/spr_width; i++)
+	{
+		draw_sprite(sprite, FRAME_TIMER * anim_speed, (round(x/spr_width) * spr_width) + spr_width * i, y);
+	}
+}

--- a/sounds/sfx_water_splash/sfx_water_splash.yy
+++ b/sounds/sfx_water_splash/sfx_water_splash.yy
@@ -10,7 +10,7 @@
   "compression":1,
   "compressionQuality":4,
   "conversionMode":0,
-  "duration":1.039206,
+  "duration":1.0392064,
   "exportDir":"",
   "name":"sfx_water_splash",
   "parent":{


### PR DESCRIPTION
This pull requests adds water pool with other utilities.

This includes 3 brand new function, such as:

- player_set_underwater(value, object = obj_water)
With this function, you can set the underwater flag without worrying about the appropriate audible and visual effects. The argument value is a boolean which determines whether the underwater should be set to true or false and the optional argument object determines where the splash effect should played.

- instance_collide_waterpool(offset_x = 0, offset_y = 0)
This function is basically a collision_point() function but reserved to obj_waterpool. The arguments offset_x and offset_y are just to offset the point, as the names are pretty self-explanatory.

- water_draw(x, y, w, h, color = $5b301e, anim_speed = 0.15, sprite = spr_water)
This function is to help keep the appearance of bodies of water consistent. The first four arguments are self-explanatory. The optional arguments color, anim_speed and sprite are to change the color of the water, change the animation's speed of the water sprite and to change the said water sprite respectively.