### PR TITLE
Make `obj_animal` use an Animator

### DIFF
--- a/objects/obj_animal/Create_0.gml
+++ b/objects/obj_animal/Create_0.gml
@@ -21,13 +21,13 @@
 	animator = new animator_create();
 
 	// Add the animal animations
-	animation_add(A_FLICKY, spr_animal_flicky, 0, 1, true);
-	animation_add(A_POCKY, spr_animal_pocky, 0, 1, true);
-	animation_add(A_CUCKY, spr_animal_cucky, 0, 1, true);
-	animation_add(A_RICKY, spr_animal_ricky, 0, 1, true);
-	animation_add(A_PECKY, spr_animal_pecky, 0, 1, true);
-	animation_add(A_ROCKY, spr_animal_rocky, 0, 1, true);
-	animation_add(A_PICKY, spr_animal_picky, 0, 1, true);
+	animation_add(A_FLICKY, spr_animal_flicky, 0, 1);
+	animation_add(A_POCKY, spr_animal_pocky, 0, 1);
+	animation_add(A_CUCKY, spr_animal_cucky, 0, 1);
+	animation_add(A_RICKY, spr_animal_ricky, 0, 1);
+	animation_add(A_PECKY, spr_animal_pecky, 0, 1);
+	animation_add(A_ROCKY, spr_animal_rocky, 0, 1);
+	animation_add(A_PICKY, spr_animal_picky, 0, 1);
 	
 	// Play the correct animation
 	animation_play(animator, animal_type);

--- a/objects/obj_animal/Create_0.gml
+++ b/objects/obj_animal/Create_0.gml
@@ -13,13 +13,24 @@
 	
 	//Animal values for different types
 	animal_type = obj_level.animal[random_animal];
-	animal_sprite = [spr_animal_flicky, spr_animal_pocky, spr_animal_cucky, spr_animal_ricky, spr_animal_pecky, spr_animal_rocky, spr_animal_picky];
 	grav_arr = [0.09375, 0.21875, 0.09375, 0.21875, 0.21875, 0.21875, 0.21875];
 	jump_force = [4, 4, 3, 3.5, 3, 1.5, 3]
 	accel = [3, 2, 2, 2.5, 1.5, 1.25, 1.75];
 	
-	//Change sprite
-	sprite_index = animal_sprite[animal_type];
+	// Create the animator
+	animator = new animator_create();
+
+	// Add the animal animations
+	animation_add(A_FLICKY, spr_animal_flicky, 0, 1, true);
+	animation_add(A_POCKY, spr_animal_pocky, 0, 1, true);
+	animation_add(A_CUCKY, spr_animal_cucky, 0, 1, true);
+	animation_add(A_RICKY, spr_animal_ricky, 0, 1, true);
+	animation_add(A_PECKY, spr_animal_pecky, 0, 1, true);
+	animation_add(A_ROCKY, spr_animal_rocky, 0, 1, true);
+	animation_add(A_PICKY, spr_animal_picky, 0, 1, true);
+	
+	// Play the correct animation
+	animation_play(animator, animal_type);
 	
 	//When creating
 	y_speed = -4;

--- a/objects/obj_animal/Draw_0.gml
+++ b/objects/obj_animal/Draw_0.gml
@@ -1,0 +1,2 @@
+/// @description 
+	draw_animator(animator);

--- a/objects/obj_animal/Step_0.gml
+++ b/objects/obj_animal/Step_0.gml
@@ -1,9 +1,9 @@
 /// @description Scripts
-	//Change frame index
-	if(!triggered) image_index = 0; else image_index = max(image_index, 1);
-	
+	animator_update(animator);
+
 	//Change animation speed
-	image_speed = 0.4;
+	if(animation_get_speed(animator) != (!triggered ? 0 : 0.4))
+		animation_set_speed(animator, !triggered ? 0 : 0.4);
 	
 	//Subtract delay timer
 	delay = max(delay-1, 0);

--- a/objects/obj_animal/obj_animal.yy
+++ b/objects/obj_animal/obj_animal.yy
@@ -4,6 +4,7 @@
   "eventList":[
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":0,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":3,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
+    {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":8,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
   ],
   "managed":true,
   "name":"obj_animal",

--- a/objects/obj_bubble_patch/Create_0.gml
+++ b/objects/obj_bubble_patch/Create_0.gml
@@ -7,5 +7,9 @@
 	bubble_flag = 0;
 	big_bubble_flag = false;
 	
+	animator = new animator_create();
+	
+	animation_play_no_list(animator, spr_water_splash, 0.3);
+	
 	instance_register_culling();
 	

--- a/objects/obj_bubble_patch/Draw_0.gml
+++ b/objects/obj_bubble_patch/Draw_0.gml
@@ -1,0 +1,2 @@
+		//Draw
+		draw_animator(animator);

--- a/objects/obj_bubble_patch/Step_0.gml
+++ b/objects/obj_bubble_patch/Step_0.gml
@@ -9,6 +9,8 @@
 		visible = true;
 	}
 
+	animator_update(animator);
+
 	if(--timer <= 0)
 	{
 		if(!bubble_flag)

--- a/objects/obj_bubble_patch/obj_bubble_patch.yy
+++ b/objects/obj_bubble_patch/obj_bubble_patch.yy
@@ -4,6 +4,7 @@
   "eventList":[
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":0,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":3,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
+    {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":8,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
   ],
   "managed":true,
   "name":"obj_bubble_patch",


### PR DESCRIPTION
This fixes a bug that's caused by how object processing was handled, where objects that impact `image_speed` don't stop and carry on as normal if object processing is paused, this is noticeable while pausing.
This fixes said bug with the animals as they're the most noticeable with that bug.