### PR TITLE
Strcuts for Backgrounds + More

### DIFF
--- a/objects/obj_aaz_bg_inside/Create_0.gml
+++ b/objects/obj_aaz_bg_inside/Create_0.gml
@@ -1,24 +1,19 @@
-/// @description Add background
-    water_layer = undefined;	
-    
+/// @description Add background	
 	//Inherit the parent event
 	event_inherited();
 	
-    with (background)
-    {
-        //Add backgrounds, ID starting out from 0, increments by 1 with each background added
-        background_add_layer(spr_bg_aaz_bottom, 5, 1, 1, 0, 0, 0, 0, false); //ID 0
-        
-        // You may use fractions as parallax factors too!
-        background_add_layer(spr_bg_aaz_ruins, 0, 2/3, 2/3, 0, 0, 0, 354, false); //ID 1
-        background_add_layer(spr_bg_aaz_ruins, 1, 2/3, 2/3, 0, 0, 0, 930, false); //ID 2
-        
-        // HCZ-like 3d water parallax
-        other.water_layer = background_add_line_layer(spr_bg_aaz_water, 1, 2/3, 2/3, 0, 0, 0, 930, 1, (2/3)/96); //ID 3 - this will be accessed later in Draw
-        
-        /* In the above example, 2/3 is the X factor of the top part of the water, and 96 is the height.
-        This allows for the top of the water parallax to be the same speed as the horizon and the bottom
-        of the water parallax to be the same speed as the foreground. In previous versions of Harmony
-        Framework the calculation for the speeds was done in a way that required extra math to be done
-        for this effect, but now it can be done with a single divison!*/    
-    }
+    //Add backgrounds, ID starting out from 0, increments by 1 with each background added
+    background_add_layer(spr_bg_aaz_bottom, 5, 1, 1, 0, 0, 0, 0, false); //ID 0
+    
+    // You may use fractions as parallax factors too!
+    background_add_layer(spr_bg_aaz_ruins, 0, 2/3, 2/3, 0, 0, 0, 354, false); //ID 1
+    background_add_layer(spr_bg_aaz_ruins, 1, 2/3, 2/3, 0, 0, 0, 930, false); //ID 2
+    
+    // HCZ-like 3d water parallax
+    water_layer = background_add_line_layer(spr_bg_aaz_water, 1, 2/3, 2/3, 0, 0, 0, 930, 1, (2/3)/96); //ID 3 - this will be accessed later in Draw
+    
+    /* In the above example, 2/3 is the X factor of the top part of the water, and 96 is the height.
+    This allows for the top of the water parallax to be the same speed as the horizon and the bottom
+    of the water parallax to be the same speed as the foreground. In previous versions of Harmony
+    Framework the calculation for the speeds was done in a way that required extra math to be done
+    for this effect, but now it can be done with a single divison!*/    

--- a/objects/obj_aaz_bg_inside/Create_0.gml
+++ b/objects/obj_aaz_bg_inside/Create_0.gml
@@ -1,20 +1,24 @@
 /// @description Add background
-	
+    water_layer = undefined;	
+    
 	//Inherit the parent event
 	event_inherited();
 	
-	//Add backgrounds, ID starting out from 0, increments by 1 with each background added
-	background_add(spr_bg_aaz_bottom, 5, 1, 1, 0, 0, 0, 0, false); //ID 0
-	
-	// You may use fractions as parallax factors too!
-	background_add(spr_bg_aaz_ruins, 0, 2/3, 2/3, 0, 0, 0, 354, false); //ID 1
-	background_add(spr_bg_aaz_ruins, 1, 2/3, 2/3, 0, 0, 0, 930, false); //ID 2
-	
-	// HCZ-like 3d water parallax
-	background_add_line(spr_bg_aaz_water, 1, 2/3, 2/3, 0, 0, 0, 930, 1, (2/3)/96); //ID 3 - this will be accessed later in Draw
-	
-	/* In the above example, 2/3 is the X factor of the top part of the water, and 96 is the height.
-	This allows for the top of the water parallax to be the same speed as the horizon and the bottom
-	of the water parallax to be the same speed as the foreground. In previous versions of Harmony
-	Framework the calculation for the speeds was done in a way that required extra math to be done
-	for this effect, but now it can be done with a single divison!*/
+    with (background)
+    {
+        //Add backgrounds, ID starting out from 0, increments by 1 with each background added
+        background_add_layer(spr_bg_aaz_bottom, 5, 1, 1, 0, 0, 0, 0, false); //ID 0
+        
+        // You may use fractions as parallax factors too!
+        background_add_layer(spr_bg_aaz_ruins, 0, 2/3, 2/3, 0, 0, 0, 354, false); //ID 1
+        background_add_layer(spr_bg_aaz_ruins, 1, 2/3, 2/3, 0, 0, 0, 930, false); //ID 2
+        
+        // HCZ-like 3d water parallax
+        other.water_layer = background_add_line_layer(spr_bg_aaz_water, 1, 2/3, 2/3, 0, 0, 0, 930, 1, (2/3)/96); //ID 3 - this will be accessed later in Draw
+        
+        /* In the above example, 2/3 is the X factor of the top part of the water, and 96 is the height.
+        This allows for the top of the water parallax to be the same speed as the horizon and the bottom
+        of the water parallax to be the same speed as the foreground. In previous versions of Harmony
+        Framework the calculation for the speeds was done in a way that required extra math to be done
+        for this effect, but now it can be done with a single divison!*/    
+    }

--- a/objects/obj_aaz_bg_inside/Draw_0.gml
+++ b/objects/obj_aaz_bg_inside/Draw_0.gml
@@ -4,10 +4,10 @@
 	// THIS NEEDS TO BE ABOVE INHERITED EVENT!
 	/*
 	if(condition == true) {
-		visibility[0] = false;
+		background.bg_layers[0].visibility = false;
 	}
 	else {
-		visibility[0] = true;
+		background.bg_layers[0].visibility = true;
 	}
 	*/
 
@@ -15,9 +15,12 @@
 	event_inherited();
 
 	//Water scale
-	if(instance_exists(obj_water))
-	{
-		var a = floor(camera_get_view_y(view_camera[view_current])*factor_y[3] + offset_y[3]); //"3" is the index of the water's parallax
-		bg_scale[3] = floor(obj_water.y - a) * (1 / 96); //"96" is the water parallax sprite's height
-		bg_scale[3] = clamp(bg_scale[3], -1, 1);
-	}
+	with (background.bg_layers[water_layer])
+    {
+    	if(instance_exists(obj_water))
+        {
+            var a = floor(camera_get_view_y(view_camera[view_current])*factor_y + offset_y); //"3" is the index of the water's parallax
+            bg_scale = floor(obj_water.y - a) * (1 / 96); //"96" is the water parallax sprite's height
+            bg_scale = clamp(bg_scale, -1, 1);
+        }
+    }

--- a/objects/obj_aaz_bg_inside/Draw_0.gml
+++ b/objects/obj_aaz_bg_inside/Draw_0.gml
@@ -4,10 +4,10 @@
 	// THIS NEEDS TO BE ABOVE INHERITED EVENT!
 	/*
 	if(condition == true) {
-		background.bg_layers[0].visibility = false;
+		bg_layers[0].visibility = false;
 	}
 	else {
-		background.bg_layers[0].visibility = true;
+		bg_layers[0].visibility = true;
 	}
 	*/
 
@@ -15,7 +15,7 @@
 	event_inherited();
 
 	//Water scale
-	with (background.bg_layers[water_layer])
+	with (bg_layers[water_layer])
     {
     	if(instance_exists(obj_water))
         {

--- a/objects/obj_aaz_bg_outside/Create_0.gml
+++ b/objects/obj_aaz_bg_outside/Create_0.gml
@@ -7,19 +7,16 @@
 	var v_scroll = 0.88;
 	
 	//Add backgrounds, ID starting out from 0, increments by 1 with each background added
-    with (background)
-    {
-        background_add_layer(spr_bg_aaz_clouds, 0, 0.9, v_scroll, -0.2, 0, 0, 0);
-        background_add_layer(spr_bg_aaz_clouds, 1, 0.93, v_scroll, -0.15, 0, 0, 0);
-        background_add_layer(spr_bg_aaz_clouds, 2, 0.95, v_scroll, -0.1, 0, 0, 0);
-        background_add_layer(spr_bg_aaz_clouds, 3, 0.97, v_scroll, -0.05, 0, 0, 0);
-        background_add_layer(spr_bg_aaz_clouds, 4, 0.99, v_scroll, 0, 0, 0, 0);
-        background_add_line_layer(spr_bg_aaz_water, 0, 0.94, v_scroll, 0, 0, 0, 128, 2, 0.006);
-        background_add_layer(spr_bg_aaz_mountains, 0, 0.98, v_scroll, 0, 0, 0, 80);
-        background_add_layer(spr_bg_aaz_mountains, 1, 0.94, v_scroll, 0, 0, 0, 80);
-        background_add_layer(spr_bg_aaz_bottom, 4, 1, v_scroll, 0, 0, 0, 164);
-        background_add_layer(spr_bg_aaz_bottom, 2, 0.84, v_scroll, 0, 0, 0, 144);
-        background_add_layer(spr_bg_aaz_bottom, 0, 0.8, v_scroll, 0, 0, 0, 144);
-        background_add_layer(spr_bg_aaz_bottom, 1, 0.78, v_scroll, 0, 0, 0, 144);
-        background_add_layer(spr_bg_aaz_bottom, 3, 0.72, v_scroll, 0, 0, 0, 144);
-    }
+    background_add_layer(spr_bg_aaz_clouds, 0, 0.9, v_scroll, -0.2, 0, 0, 0);
+    background_add_layer(spr_bg_aaz_clouds, 1, 0.93, v_scroll, -0.15, 0, 0, 0);
+    background_add_layer(spr_bg_aaz_clouds, 2, 0.95, v_scroll, -0.1, 0, 0, 0);
+    background_add_layer(spr_bg_aaz_clouds, 3, 0.97, v_scroll, -0.05, 0, 0, 0);
+    background_add_layer(spr_bg_aaz_clouds, 4, 0.99, v_scroll, 0, 0, 0, 0);
+    background_add_line_layer(spr_bg_aaz_water, 0, 0.94, v_scroll, 0, 0, 0, 128, 2, 0.006);
+    background_add_layer(spr_bg_aaz_mountains, 0, 0.98, v_scroll, 0, 0, 0, 80);
+    background_add_layer(spr_bg_aaz_mountains, 1, 0.94, v_scroll, 0, 0, 0, 80);
+    background_add_layer(spr_bg_aaz_bottom, 4, 1, v_scroll, 0, 0, 0, 164);
+    background_add_layer(spr_bg_aaz_bottom, 2, 0.84, v_scroll, 0, 0, 0, 144);
+    background_add_layer(spr_bg_aaz_bottom, 0, 0.8, v_scroll, 0, 0, 0, 144);
+    background_add_layer(spr_bg_aaz_bottom, 1, 0.78, v_scroll, 0, 0, 0, 144);
+    background_add_layer(spr_bg_aaz_bottom, 3, 0.72, v_scroll, 0, 0, 0, 144);

--- a/objects/obj_aaz_bg_outside/Create_0.gml
+++ b/objects/obj_aaz_bg_outside/Create_0.gml
@@ -7,16 +7,19 @@
 	var v_scroll = 0.88;
 	
 	//Add backgrounds, ID starting out from 0, increments by 1 with each background added
-	background_add(spr_bg_aaz_clouds, 0, 0.9, v_scroll, -0.2, 0, 0, 0);
-	background_add(spr_bg_aaz_clouds, 1, 0.93, v_scroll, -0.15, 0, 0, 0);
-	background_add(spr_bg_aaz_clouds, 2, 0.95, v_scroll, -0.1, 0, 0, 0);
-	background_add(spr_bg_aaz_clouds, 3, 0.97, v_scroll, -0.05, 0, 0, 0);
-	background_add(spr_bg_aaz_clouds, 4, 0.99, v_scroll, 0, 0, 0, 0);
-	background_add_line(spr_bg_aaz_water, 0, 0.94, v_scroll, 0, 0, 0, 128, 2, 0.006);
-	background_add(spr_bg_aaz_mountains, 0, 0.98, v_scroll, 0, 0, 0, 80);
-	background_add(spr_bg_aaz_mountains, 1, 0.94, v_scroll, 0, 0, 0, 80);
-	background_add(spr_bg_aaz_bottom, 4, 1, v_scroll, 0, 0, 0, 164);
-	background_add(spr_bg_aaz_bottom, 2, 0.84, v_scroll, 0, 0, 0, 144);
-	background_add(spr_bg_aaz_bottom, 0, 0.8, v_scroll, 0, 0, 0, 144);
-	background_add(spr_bg_aaz_bottom, 1, 0.78, v_scroll, 0, 0, 0, 144);
-	background_add(spr_bg_aaz_bottom, 3, 0.72, v_scroll, 0, 0, 0, 144);
+    with (background)
+    {
+        background_add_layer(spr_bg_aaz_clouds, 0, 0.9, v_scroll, -0.2, 0, 0, 0);
+        background_add_layer(spr_bg_aaz_clouds, 1, 0.93, v_scroll, -0.15, 0, 0, 0);
+        background_add_layer(spr_bg_aaz_clouds, 2, 0.95, v_scroll, -0.1, 0, 0, 0);
+        background_add_layer(spr_bg_aaz_clouds, 3, 0.97, v_scroll, -0.05, 0, 0, 0);
+        background_add_layer(spr_bg_aaz_clouds, 4, 0.99, v_scroll, 0, 0, 0, 0);
+        background_add_line_layer(spr_bg_aaz_water, 0, 0.94, v_scroll, 0, 0, 0, 128, 2, 0.006);
+        background_add_layer(spr_bg_aaz_mountains, 0, 0.98, v_scroll, 0, 0, 0, 80);
+        background_add_layer(spr_bg_aaz_mountains, 1, 0.94, v_scroll, 0, 0, 0, 80);
+        background_add_layer(spr_bg_aaz_bottom, 4, 1, v_scroll, 0, 0, 0, 164);
+        background_add_layer(spr_bg_aaz_bottom, 2, 0.84, v_scroll, 0, 0, 0, 144);
+        background_add_layer(spr_bg_aaz_bottom, 0, 0.8, v_scroll, 0, 0, 0, 144);
+        background_add_layer(spr_bg_aaz_bottom, 1, 0.78, v_scroll, 0, 0, 0, 144);
+        background_add_layer(spr_bg_aaz_bottom, 3, 0.72, v_scroll, 0, 0, 0, 144);
+    }

--- a/objects/obj_act_transition/Create_0.gml
+++ b/objects/obj_act_transition/Create_0.gml
@@ -36,8 +36,8 @@
 		};
 		
 		for (var n = 0; n < bg.bg_id; ++n) {
-			array_push(data.list_x, bg.diff_x[n]);
-			array_push(data.list_y, bg.diff_y[n]);
+			array_push(data.list_x, bg.bg_layers[n].diff_x);
+			array_push(data.list_y, bg.bg_layers[n].diff_y);
 		}
 		variable_struct_set(background_store, name, data);
 	}

--- a/objects/obj_bg_base/Create_0.gml
+++ b/objects/obj_bg_base/Create_0.gml
@@ -7,4 +7,4 @@
 	var v_scroll = 0.7;
 	
 	//Add backgrounds, ID starting out from 0, increments by 1 with each background added
-	background_add(spr_bg_base, 0, 0.7, v_scroll, -0.25, -0.25, 0, 0, true);
+	background_add_layer(spr_bg_base, 0, 0.7, v_scroll, -0.25, -0.25, 0, 0, true);

--- a/objects/obj_bg_bonus/Create_0.gml
+++ b/objects/obj_bg_bonus/Create_0.gml
@@ -4,5 +4,5 @@
 	event_inherited();
 	
 	//Add backgrounds, ID starting out from 0, increments by 1 with each background added
-	background_add(spr_bg_bonus, 0, 1, 0.75, 0, 0, 0, 0, true);
-	background_add(spr_bg_bonus, 1, 1, 0.5, 0, 0, 0, 0, true);
+	background_add_layer(spr_bg_bonus, 0, 1, 0.75, 0, 0, 0, 0, true);
+	background_add_layer(spr_bg_bonus, 1, 1, 0.5, 0, 0, 0, 0, true);

--- a/objects/obj_loop_end/Step_1.gml
+++ b/objects/obj_loop_end/Step_1.gml
@@ -7,7 +7,7 @@
 		{
 			for(var i = 0; i <= bg_id; i++)
 			{
-				offset_x[i] -= (obj_player.x - obj_loop_start.x) * (1-factor_x[i]);
+				bg_layers[i].offset_x -= (obj_player.x - obj_loop_start.x) * (1-bg_layers[i].factor_x);
 			}
 		}
 		obj_camera.target_x -= obj_player.x - obj_loop_start.x;

--- a/objects/par_background/Create_0.gml
+++ b/objects/par_background/Create_0.gml
@@ -1,22 +1,2 @@
 /// @description Values
-	
-	background_sprite = [];
-	background_frame = [];
-	factor_x = [];
-	factor_y = [];
-	offset_x = [];
-	offset_y = [];
-	speed_x = [];
-	speed_y = [];
-	pos_x = [];
-	pos_y = [];
-	background_vertical = [];
-	line_scroll = [];
-	line_gap = [];
-	line_steps = [];
-	bg_scale = [];
-	diff_x = [];
-	diff_y = [];
-	trigger = [];
-	
-	bg_id = 0;
+	background = new background_create();

--- a/objects/par_background/Create_0.gml
+++ b/objects/par_background/Create_0.gml
@@ -1,2 +1,3 @@
 /// @description Values
-	background = new background_create();
+	bg_layers = [];
+    bg_id = 0;

--- a/objects/par_background/Draw_0.gml
+++ b/objects/par_background/Draw_0.gml
@@ -1,6 +1,12 @@
 /// @description Draw background
-	for(var i = 0; i < bg_id; i++)
-	{
-		background_position_layer(i);
-		background_draw_layer(i);
-	}
+    with (background) {
+        for(var i = 0; i < bg_id; i++)
+        {
+            with(bg_layers[i])
+            {
+                background_update_layer_values();
+                background_position_layer();
+                background_draw_layer();
+            }
+        }	
+    }

--- a/objects/par_background/Draw_0.gml
+++ b/objects/par_background/Draw_0.gml
@@ -1,12 +1,10 @@
 /// @description Draw background
-    with (background) {
-        for(var i = 0; i < bg_id; i++)
+    for(var i = 0; i < bg_id; i++)
+    {
+        with(bg_layers[i])
         {
-            with(bg_layers[i])
-            {
-                background_update_layer_values();
-                background_position_layer();
-                background_draw_layer();
-            }
-        }	
-    }
+            background_update_layer_values();
+            background_position_layer();
+            background_draw_layer();
+        }
+    }	

--- a/scripts/background_util/background_util.gml
+++ b/scripts/background_util/background_util.gml
@@ -1,140 +1,279 @@
-function background_add(sprite, frame, scroll_x, scroll_y, spd_x=0, spd_y=0, off_x=0, off_y=0, vertical_loop = false)
+function background_create() constructor
 {
-	var oldId = bg_id;
-	
-	background_sprite[bg_id] = sprite;
-	background_frame[bg_id] = frame;
-	factor_x[bg_id] = scroll_x;
-	factor_y[bg_id] = scroll_y;
-	speed_x[bg_id] = spd_x;
-	speed_y[bg_id] = spd_y;
-	offset_x[bg_id] = off_x;
-	offset_y[bg_id] = off_y;
-	background_vertical[bg_id] = vertical_loop;
-	line_scroll[bg_id] = false;
-	trigger[bg_id] = false;
-	visibility[bg_id] = true;
-	bg_id++;
-	
-	return oldId;
+    bg_layers = [];
+    bg_id = 0;
+    
+    static background_add_layer = function(sprite, frame, scroll_x, scroll_y, spd_x=0, spd_y=0, off_x=0, off_y=0, vertical_loop=false)
+    {
+        var oldId = bg_id;
+        
+        bg_layers[bg_id] = {
+            background_sprite: sprite,
+            background_sprite: sprite,
+            background_frame: frame,
+            factor_x: scroll_x,
+            factor_y: scroll_y,
+            speed_x: spd_x,
+            speed_y: spd_y,
+            offset_x: off_x,
+            offset_y: off_y,
+            background_vertical: vertical_loop,
+            
+            line_scroll: false,
+            visibility: true,
+            trigger: false,
+            
+            anim_speed: 0,
+            alpha: 1,
+            
+            blend: {
+                mode: undefined,
+                src: undefined,
+                dst: undefined,
+                eq: undefined,
+                eq_alpha: undefined,
+            },
+            
+            palette_swapper: undefined, //Add support for palette swapper constructor later...
+        }
+        bg_id++;
+        
+        return oldId;
+    }
+    
+    static background_add_line_layer = function(sprite, frame, scroll_x, scroll_y, spd_x, spd_y, off_x, off_y, gaps, steps, y_scale=1)
+    {
+        var oldId = bg_id;
+        
+        bg_layers[bg_id] = {
+            background_sprite: sprite,
+            background_frame: frame,
+            factor_x: scroll_x,
+            factor_y: scroll_y,
+            speed_x: spd_x,
+            speed_y: spd_y,
+            offset_x: off_x,
+            offset_y: off_y,
+            line_gap: gaps,
+            line_steps: steps,
+            bg_scale: y_scale,
+            
+            background_vertical: false,
+            line_scroll: true,
+            trigger: false,
+            visibility: true,
+            
+            anim_speed: 0,
+            alpha: 1,
+            
+            blend: {
+                mode: undefined,
+                src: undefined,
+                dst: undefined,
+                eq: undefined,
+                eq_alpha: undefined,
+            },
+            
+            palette_swapper: undefined, //Add support for palette swapper constructor later...
+        }
+        bg_id++;
+        
+        return oldId;
+    }
+    
+    static background_layer_set_animation_speed = function(layer_id, speed=0)
+    {
+        bg_layers[layer_id].anim_speed = speed;
+    }
+    
+    static background_layer_set_alpha = function(layer_id, alpha=1)
+    {
+        bg_layers[layer_id].alpha = alpha;
+    }
+    
+    /// @description                 Set a blendmode to a background layer from a list of preset blend modes, coresponding to the given layer ID.
+    /// @param {layer_id}   layer_id The ID of the background layer.
+    /// @param {mode}       mode     The blendmode preset name. The options are: "lighten", "darken", "addition", and "multiply".
+    static background_layer_set_blendmode_preset = function(layer_id, mode = "normal")
+    {
+        with(bg_layers[layer_id]) {
+        	switch(mode) {
+                case "lighten":
+                    blend.src = bm_one;
+                    blend.dst = bm_dest_color;
+                    
+                    blend.eq = bm_eq_max;
+                    blend.eq_alpha = bm_eq_add;
+                break;
+                case "darken":
+                    blend.src = bm_one;
+                    blend.dst = bm_dest_color;
+                    
+                    blend.eq = bm_eq_min;
+                    blend.eq_alpha = bm_eq_add;
+                break;
+                case "addition":
+                    blend.mode = bm_add;
+                break;
+                case "multiply":
+                    blend.src = bm_zero;
+                    blend.dst = bm_src_color;
+                break;
+            }
+        }
+    }
+    
+    /// @description                 Set a blendmode to a background layer coresponding to the given layer ID.
+    /// @param {layer_id}   layer_id The ID of the background layer.
+    /// @param {mode}       mode     The blendmode constant. It can either take a singular blendmode constant (ex. bm_add) or an array that contains source and destination blendmode factors (ex. [ bm_one, bm_dest_color ]).
+    static background_layer_set_blendmode = function(layer_id, mode)
+    {
+        if(is_array(mode)) {
+            bg_layers[layer_id].blend.src = mode[0];
+            bg_layers[layer_id].blend.dst = mode[1];
+        }
+        else {
+            bg_layers[layer_id].blend.mode = mode;
+        }
+        
+    }
+    
+    /// @description                           Set a blendequation to a background layer coresponding to the given layer ID.
+    /// @param {layer_id}       layer_id       The ID of the background layer.
+    /// @param {equation}       equation       The blendequation constant.
+    /// @param {equation_alpha} equation_alpha The blendequation constant for the alpha channel.
+    static background_layer_set_blendequation = function(layer_id, equation, equation_alpha = undefined)
+    {
+        bg_layers[layer_id].blend.eq = equation;
+        bg_layers[layer_id].blend.eq_alpha = equation_alpha;
+    }
 }
 
-function background_add_line(sprite, frame, scroll_x, scroll_y, spd_x, spd_y, off_x, off_y, gaps, steps, y_scale = 1)
+function background_draw_layer()
 {
-	var oldId = bg_id;
-	
-	background_sprite[bg_id] = sprite;
-	background_frame[bg_id] = frame;
-	factor_x[bg_id] = scroll_x;
-	factor_y[bg_id] = scroll_y;
-	speed_x[bg_id] = spd_x;
-	speed_y[bg_id] = spd_y;
-	offset_x[bg_id] = off_x;
-	offset_y[bg_id] = off_y;
-	background_vertical[bg_id] = false;
-	line_scroll[bg_id] = true;
-	line_gap[bg_id] = gaps;
-	line_steps[bg_id] = steps;
-	bg_scale[bg_id] = y_scale;
-	trigger[bg_id] = false;
-	visibility[bg_id] = true;
-	bg_id++;
-	
-	return oldId;
+    if(!visibility) 
+        exit;
+    
+    //Draw the background
+    if(!line_scroll)
+    {
+        draw_sprite_tiled_new(background_sprite, background_frame, floor(pos_x), floor(pos_y), background_vertical ? 2 : 0);
+    }
+    else
+    {
+        //Set the linescroll shader
+        shader_set(shd_line_scroll);
+        
+        //Get shader's uniforms
+        var BGWidth = shader_get_uniform(shd_line_scroll, "Width");
+        var BGTexel = shader_get_uniform(shd_line_scroll, "TexelWidth");
+        var OffX = shader_get_uniform(shd_line_scroll, "OffsetX");
+        var PosX = shader_get_uniform(shd_line_scroll, "Position");
+        var HeightY = shader_get_uniform(shd_line_scroll, "LineGaps");
+        var StepY = shader_get_uniform(shd_line_scroll, "YSteps");
+        var ScaleY = shader_get_uniform(shd_line_scroll, "YScale");
+        var ShdHeight = shader_get_uniform(shd_line_scroll, "Height");
+        
+        var repSize = (camera_get_view_width(view_camera[view_current]) / sprite_get_width(background_sprite));
+        
+        for (var i = -1; i < repSize; ++i) 
+        {
+            var px = camera_get_view_x(view_camera[view_current]) + sprite_get_width(background_sprite) * i;
+        
+            //Set shader uniforms
+            shader_set_uniform_f(BGWidth, sprite_get_width(background_sprite));
+            shader_set_uniform_f(BGTexel, texture_get_texel_width(sprite_get_texture(background_sprite, 0)));
+            shader_set_uniform_f(OffX, pos_x);
+            shader_set_uniform_f(PosX, px, pos_y);
+            shader_set_uniform_f(StepY, line_steps/(1-factor_x));
+            shader_set_uniform_f(HeightY, line_gap);
+            shader_set_uniform_f(ScaleY, bg_scale); 
+            shader_set_uniform_f(ShdHeight, sprite_get_height(background_sprite)); 
+            
+            draw_sprite_ext(background_sprite, background_frame, px, floor(pos_y) , 1, bg_scale, 0, c_white, alpha);
+        }
+    }
+    
+    //Reset the values
+    shader_reset();
+    draw_set_alpha(1);
+    gpu_set_blendmode(bm_normal);
+    gpu_set_blendequation(bm_eq_add);
 }
 
-function background_draw_layer(background_layer)
+function background_position_layer()
 {
-	if(!visibility[background_layer]) 
-		exit;
-	
-	//Draw the background
-	if(!line_scroll[background_layer])
-	{
-		draw_sprite_tiled_new(background_sprite[background_layer], background_frame[background_layer], floor(pos_x[background_layer]), floor(pos_y[background_layer]), background_vertical[background_layer] ? 2 : 0);
-	}
-	else
-	{
-		//Set the linescroll shader
-		shader_set(shd_line_scroll);
-		
-		//Get shader's uniforms
-		var BGWidth = shader_get_uniform(shd_line_scroll, "Width");
-		var BGTexel = shader_get_uniform(shd_line_scroll, "TexelWidth");
-		var OffX = shader_get_uniform(shd_line_scroll, "OffsetX");
-		var PosX = shader_get_uniform(shd_line_scroll, "Position");
-		var HeightY = shader_get_uniform(shd_line_scroll, "LineGaps");
-		var StepY = shader_get_uniform(shd_line_scroll, "YSteps");
-		var ScaleY = shader_get_uniform(shd_line_scroll, "YScale");
-		var ShdHeight = shader_get_uniform(shd_line_scroll, "Height");
-		
-		var repSize = (camera_get_view_width(view_camera[view_current]) / sprite_get_width(background_sprite[background_layer]));
-		
-		for (var i = -1; i < repSize; ++i) 
-		{
-		    var px = camera_get_view_x(view_camera[view_current]) + sprite_get_width(background_sprite[background_layer]) * i;
-		
-			//Set shader uniforms
-			shader_set_uniform_f(BGWidth, sprite_get_width(background_sprite[background_layer]));
-			shader_set_uniform_f(BGTexel, texture_get_texel_width(sprite_get_texture(background_sprite[background_layer], 0)));
-			shader_set_uniform_f(OffX, pos_x[background_layer]);
-			shader_set_uniform_f(PosX, px, pos_y[background_layer]);
-			shader_set_uniform_f(StepY, line_steps[background_layer]/(1-factor_x[background_layer]));
-			shader_set_uniform_f(HeightY, line_gap[background_layer]);
-			shader_set_uniform_f(ScaleY, bg_scale[background_layer]); 
-			shader_set_uniform_f(ShdHeight, sprite_get_height(background_sprite[background_layer])); 
-			
-			draw_sprite_ext(background_sprite[background_layer], background_frame[background_layer], px, floor(pos_y[background_layer]) , 1, bg_scale[background_layer], 0, c_white, 1);
-		}
-	}
-	
-	//Reset the shader
-	shader_reset();
+    //Act transition background offset adjustments
+    if(trigger)
+    {
+        //Horizontal offset
+        var reposition_x =  ((camera_get_view_x(view_camera[view_current])*factor_x) + offset_x)
+        diff_x = reposition_x - camera_get_view_x(view_camera[view_current]);
+        offset_x += offset_x - diff_x
+            
+        //Vertical offset
+        var reposition_y =  ((camera_get_view_y(view_camera[view_current])*factor_y) + offset_y)
+        diff_y = reposition_y - camera_get_view_y(view_camera[view_current]);
+        offset_y += offset_y - diff_y
+            
+        //Disable the trigger
+        trigger = false;
+    }
+    
+    //Different types of scrolling
+    if(!line_scroll)
+    {
+        //Normal scrolling
+        pos_x = ((camera_get_view_x(view_camera[view_current])*factor_x) + offset_x)
+        pos_y = floor(camera_get_view_y(view_camera[view_current])*factor_y + offset_y);
+        
+        diff_x = pos_x - camera_get_view_x(view_camera[view_current]);
+        diff_y = pos_y - camera_get_view_y(view_camera[view_current]);
+    }
+    else
+    {
+        //Normal scrolling
+        pos_x = ((camera_get_view_x(view_camera[view_current])*(1-factor_x)) - offset_x);
+        pos_y = floor(camera_get_view_y(view_camera[view_current])*factor_y + offset_y);
+        
+        diff_x = ((camera_get_view_x(view_camera[view_current])*factor_x) + offset_x) - camera_get_view_x(view_camera[view_current])
+        diff_y = (floor(camera_get_view_y(view_camera[view_current])*factor_y) + offset_y) - camera_get_view_y(view_camera[view_current])
+    }
+        
+    //Auto scrolling
+    if(global.process_objects)
+    {
+        offset_x += speed_x;
+        offset_y += speed_y;
+    }
 }
 
-function background_position_layer(background_layer)
+function background_update_layer_values()
 {
-	//Act transition background offset adjustments
-	if(trigger[background_layer])
-	{
-		//Horizontal offset
-		var reposition_x =  ((camera_get_view_x(view_camera[view_current])*factor_x[background_layer]) + offset_x[background_layer])
-		diff_x[background_layer] = reposition_x - camera_get_view_x(view_camera[view_current]);
-		offset_x[background_layer] += offset_x[background_layer] - diff_x[background_layer]
-			
-		//Vertical offset
-		var reposition_y =  ((camera_get_view_y(view_camera[view_current])*factor_y[background_layer]) + offset_y[background_layer])
-		diff_y[background_layer] = reposition_y - camera_get_view_y(view_camera[view_current]);
-		offset_y[background_layer] += offset_y[background_layer] - diff_y[background_layer]
-			
-		//Disable the trigger
-		trigger[background_layer] = false;
-	}
-	
-	//Different types of scrolling
-	if(!line_scroll[background_layer])
-	{
-		//Normal scrolling
-		pos_x[background_layer] = ((camera_get_view_x(view_camera[view_current])*factor_x[background_layer]) + offset_x[background_layer])
-		pos_y[background_layer] = floor(camera_get_view_y(view_camera[view_current])*factor_y[background_layer] + offset_y[background_layer]);
-		
-		diff_x[background_layer] = pos_x[background_layer] - camera_get_view_x(view_camera[view_current]);
-		diff_y[background_layer] = pos_y[background_layer] - camera_get_view_y(view_camera[view_current]);
-	}
-	else
-	{
-		//Normal scrolling
-		pos_x[background_layer] = ((camera_get_view_x(view_camera[view_current])*(1-factor_x[background_layer])) - offset_x[background_layer]);
-		pos_y[background_layer] = floor(camera_get_view_y(view_camera[view_current])*factor_y[background_layer] + offset_y[background_layer]);
-		
-		diff_x[background_layer] = ((camera_get_view_x(view_camera[view_current])*factor_x[background_layer]) + offset_x[background_layer]) - camera_get_view_x(view_camera[view_current])
-		diff_y[background_layer] = (floor(camera_get_view_y(view_camera[view_current])*factor_y[background_layer]) + offset_y[background_layer]) - camera_get_view_y(view_camera[view_current])
-	}
-		
-	//Auto scrolling
-	if(global.process_objects)
-	{
-		offset_x[background_layer] += speed_x[background_layer];
-		offset_y[background_layer] += speed_y[background_layer];
-	}
+    //Sprite Animation
+        if (anim_speed != 0) background_frame += anim_speed;
+    
+    //Alpha
+        draw_set_alpha(alpha);
+    
+    //Blendmodes
+        if(blend.src && blend.dst) {
+            gpu_set_blendmode_ext(blend.src, blend.dst);
+            gpu_set_alphatestenable(true);
+        }
+        else if(blend.mode) {
+            gpu_set_blendmode(blend.mode);
+        }
+    
+    //Blendequations
+        if(blend.eq && blend.eq_alpha) {
+            gpu_set_blendequation_sepalpha(blend.eq, blend.eq_alpha);
+            gpu_set_alphatestenable(true);
+        }
+        else if(blend.eq) {
+            gpu_set_blendequation(blend.eq);
+        }
+    
+    //Add support for palette swapper constructor later...
+    
 }

--- a/scripts/background_util/background_util.gml
+++ b/scripts/background_util/background_util.gml
@@ -1,152 +1,146 @@
-function background_create() constructor
+function background_add_layer(sprite, frame, scroll_x, scroll_y, spd_x=0, spd_y=0, off_x=0, off_y=0, vertical_loop=false)
 {
-    bg_layers = [];
-    bg_id = 0;
+    var oldId = bg_id;
     
-    static background_add_layer = function(sprite, frame, scroll_x, scroll_y, spd_x=0, spd_y=0, off_x=0, off_y=0, vertical_loop=false)
-    {
-        var oldId = bg_id;
+    bg_layers[bg_id] = {
+        background_sprite: sprite,
+        background_sprite: sprite,
+        background_frame: frame,
+        factor_x: scroll_x,
+        factor_y: scroll_y,
+        speed_x: spd_x,
+        speed_y: spd_y,
+        offset_x: off_x,
+        offset_y: off_y,
+        background_vertical: vertical_loop,
         
-        bg_layers[bg_id] = {
-            background_sprite: sprite,
-            background_sprite: sprite,
-            background_frame: frame,
-            factor_x: scroll_x,
-            factor_y: scroll_y,
-            speed_x: spd_x,
-            speed_y: spd_y,
-            offset_x: off_x,
-            offset_y: off_y,
-            background_vertical: vertical_loop,
-            
-            line_scroll: false,
-            visibility: true,
-            trigger: false,
-            
-            anim_speed: 0,
-            alpha: 1,
-            
-            blend: {
-                mode: undefined,
-                src: undefined,
-                dst: undefined,
-                eq: undefined,
-                eq_alpha: undefined,
-            },
-            
-            palette_swapper: undefined, //Add support for palette swapper constructor later...
-        }
-        bg_id++;
+        line_scroll: false,
+        visibility: true,
+        trigger: false,
         
-        return oldId;
-    }
-    
-    static background_add_line_layer = function(sprite, frame, scroll_x, scroll_y, spd_x, spd_y, off_x, off_y, gaps, steps, y_scale=1)
-    {
-        var oldId = bg_id;
+        anim_speed: 0,
+        alpha: 1,
         
-        bg_layers[bg_id] = {
-            background_sprite: sprite,
-            background_frame: frame,
-            factor_x: scroll_x,
-            factor_y: scroll_y,
-            speed_x: spd_x,
-            speed_y: spd_y,
-            offset_x: off_x,
-            offset_y: off_y,
-            line_gap: gaps,
-            line_steps: steps,
-            bg_scale: y_scale,
-            
-            background_vertical: false,
-            line_scroll: true,
-            trigger: false,
-            visibility: true,
-            
-            anim_speed: 0,
-            alpha: 1,
-            
-            blend: {
-                mode: undefined,
-                src: undefined,
-                dst: undefined,
-                eq: undefined,
-                eq_alpha: undefined,
-            },
-            
-            palette_swapper: undefined, //Add support for palette swapper constructor later...
-        }
-        bg_id++;
+        blend: {
+            mode: undefined,
+            src: undefined,
+            dst: undefined,
+            eq: undefined,
+            eq_alpha: undefined,
+        },
         
-        return oldId;
+        palette_swapper: undefined,
     }
+    bg_id++;
     
-    static background_layer_set_animation_speed = function(layer_id, speed=0)
-    {
-        bg_layers[layer_id].anim_speed = speed;
+    return oldId;
+}
+
+function background_add_line_layer(sprite, frame, scroll_x, scroll_y, spd_x, spd_y, off_x, off_y, gaps, steps, y_scale=1)
+{
+    var oldId = bg_id;
+    
+    bg_layers[bg_id] = {
+        background_sprite: sprite,
+        background_frame: frame,
+        factor_x: scroll_x,
+        factor_y: scroll_y,
+        speed_x: spd_x,
+        speed_y: spd_y,
+        offset_x: off_x,
+        offset_y: off_y,
+        line_gap: gaps,
+        line_steps: steps,
+        bg_scale: y_scale,
+        
+        background_vertical: false,
+        line_scroll: true,
+        trigger: false,
+        visibility: true,
+        
+        anim_speed: 0,
+        alpha: 1,
+        
+        blend: {
+            mode: undefined,
+            src: undefined,
+            dst: undefined,
+            eq: undefined,
+            eq_alpha: undefined,
+        },
+        
+        palette_swapper: undefined,
     }
+    bg_id++;
     
-    static background_layer_set_alpha = function(layer_id, alpha=1)
-    {
-        bg_layers[layer_id].alpha = alpha;
-    }
-    
-    /// @description                 Set a blendmode to a background layer from a list of preset blend modes, coresponding to the given layer ID.
-    /// @param {layer_id}   layer_id The ID of the background layer.
-    /// @param {mode}       mode     The blendmode preset name. The options are: "lighten", "darken", "addition", and "multiply".
-    static background_layer_set_blendmode_preset = function(layer_id, mode = "normal")
-    {
-        with(bg_layers[layer_id]) {
-        	switch(mode) {
-                case "lighten":
-                    blend.src = bm_one;
-                    blend.dst = bm_dest_color;
-                    
-                    blend.eq = bm_eq_max;
-                    blend.eq_alpha = bm_eq_add;
-                break;
-                case "darken":
-                    blend.src = bm_one;
-                    blend.dst = bm_dest_color;
-                    
-                    blend.eq = bm_eq_min;
-                    blend.eq_alpha = bm_eq_add;
-                break;
-                case "addition":
-                    blend.mode = bm_add;
-                break;
-                case "multiply":
-                    blend.src = bm_zero;
-                    blend.dst = bm_src_color;
-                break;
-            }
+    return oldId;
+}
+
+function background_layer_set_animation_speed(layer_id, speed=0)
+{
+    bg_layers[layer_id].anim_speed = speed;
+}
+
+function background_layer_set_alpha(layer_id, alpha=1)
+{
+    bg_layers[layer_id].alpha = alpha;
+}
+
+/// @description    Set a blendmode to a background layer from a list of preset blend modes, coresponding to the given layer ID.
+/// @param {Real}   layer_id The ID of the background layer.
+/// @param {String} mode     The blendmode preset name. The options are: "lighten", "darken", "addition", and "multiply".
+function background_layer_set_blendmode_preset(layer_id, mode = "normal")
+{
+    with(bg_layers[layer_id]) {
+        switch(mode) {
+            case "lighten":
+                blend.src = bm_one;
+                blend.dst = bm_dest_color;
+                
+                blend.eq = bm_eq_max;
+                blend.eq_alpha = bm_eq_add;
+            break;
+            case "darken":
+                blend.src = bm_one;
+                blend.dst = bm_dest_color;
+                
+                blend.eq = bm_eq_min;
+                blend.eq_alpha = bm_eq_add;
+            break;
+            case "addition":
+                blend.mode = bm_add;
+            break;
+            case "multiply":
+                blend.src = bm_zero;
+                blend.dst = bm_src_color;
+            break;
         }
     }
-    
-    /// @description                 Set a blendmode to a background layer coresponding to the given layer ID.
-    /// @param {layer_id}   layer_id The ID of the background layer.
-    /// @param {mode}       mode     The blendmode constant. It can either take a singular blendmode constant (ex. bm_add) or an array that contains source and destination blendmode factors (ex. [ bm_one, bm_dest_color ]).
-    static background_layer_set_blendmode = function(layer_id, mode)
-    {
-        if(is_array(mode)) {
-            bg_layers[layer_id].blend.src = mode[0];
-            bg_layers[layer_id].blend.dst = mode[1];
-        }
-        else {
-            bg_layers[layer_id].blend.mode = mode;
-        }
-        
+}
+
+/// @description                Set a blendmode to a background layer coresponding to the given layer ID.
+/// @param {Real}               layer_id
+/// @param {Constant.BlendMode} mode The blendmode constant. It can either take a singular Constant.BlendMode constant (ex. bm_add) or an array that contains source and destination Constant.BlendModeFactor's (ex. [ bm_one, bm_dest_color ]).
+function background_layer_set_blendmode(layer_id, mode)
+{
+    if(is_array(mode)) {
+        bg_layers[layer_id].blend.src = mode[0];
+        bg_layers[layer_id].blend.dst = mode[1];
+    }
+    else {
+        bg_layers[layer_id].blend.mode = mode;
     }
     
-    /// @description                           Set a blendequation to a background layer coresponding to the given layer ID.
-    /// @param {layer_id}       layer_id       The ID of the background layer.
-    /// @param {equation}       equation       The blendequation constant.
-    /// @param {equation_alpha} equation_alpha The blendequation constant for the alpha channel.
-    static background_layer_set_blendequation = function(layer_id, equation, equation_alpha = undefined)
-    {
-        bg_layers[layer_id].blend.eq = equation;
-        bg_layers[layer_id].blend.eq_alpha = equation_alpha;
-    }
+}
+
+/// @description                        Set a blendequation to a background layer coresponding to the given layer ID.
+/// @param {Real}                       layer_id
+/// @param {Constant.BlendModeEquation} equation
+/// @param {Constant.BlendModeEquation} equation_alpha
+function background_layer_set_blendequation(layer_id, equation, equation_alpha = undefined)
+{
+    bg_layers[layer_id].blend.eq = equation;
+    bg_layers[layer_id].blend.eq_alpha = equation_alpha;
 }
 
 function background_draw_layer()
@@ -274,6 +268,9 @@ function background_update_layer_values()
             gpu_set_blendequation(blend.eq);
         }
     
-    //Add support for palette swapper constructor later...
-    
+    //Palette Swapper (If the Palette Swapper PR passes)
+        /*
+        palette_swapper_update(palette_swapper);
+        palette_swapper_draw(palette_swapper);
+        */
 }

--- a/scripts/background_util/background_util.gml
+++ b/scripts/background_util/background_util.gml
@@ -270,7 +270,10 @@ function background_update_layer_values()
     
     //Palette Swapper (If the Palette Swapper PR passes)
         /*
-        palette_swapper_update(palette_swapper);
-        palette_swapper_draw(palette_swapper);
+        if(palette_swapper)
+        {
+            palette_swapper_update(palette_swapper);
+            palette_swapper_draw(palette_swapper);
+        }
         */
 }


### PR DESCRIPTION
This PR (EVEN THOUGH DARK SAID HE'D KILL ME 💖) removes all arrays from the background object (except one that holds all layers) and uses Structs instead. It also adds the ability to:
- change a background layer's alpha value,
- animate a background layer's sprite through a dedicated speed value,
- add a Palette Swapper inside a background layer (through PR #145),
- and the ability to use blendmodes inside a background layer (either through giving the blend mode values by hand or picking from preset blendmodes I've added).