### PR TITLE
Finally shut Feather up + Re-implement Gamepad Index Async detection.

### DIFF
--- a/objects/obj_aaz2_boss/Other_11.gml
+++ b/objects/obj_aaz2_boss/Other_11.gml
@@ -35,7 +35,7 @@
 	{
 		if(f == 1 && x > found_collision.x)
 		{
-			boss_state = AAZ2_BSTATE.SPIKE_DROP;;
+			boss_state = AAZ2_BSTATE.SPIKE_DROP;
 			x = found_collision.x;
 			exit;
 		}

--- a/objects/obj_breakable_tile/Destroy_0.gml
+++ b/objects/obj_breakable_tile/Destroy_0.gml
@@ -28,8 +28,8 @@
 	//Get position only for the breakable floor
 	if(breakable_type != "Wall")
 	{
-		var startX	= x + (sprite_width / 2);
-		var startY	= bbox_bottom;
+		startX	= x + (sprite_width / 2);
+		startY	= bbox_bottom;
 	}
 		
 	var curY = endY - startY;
@@ -49,11 +49,13 @@
 			//Remove tiles from the area
 			tilemap_set_at_pixel(tilelayer, 0, tile.x, tile.y)
 				
+			//Main Angle
+			var angle	= darctan2(angleX, curY);
+			
 			switch(breakable_type)
 			{
 				case "Wall":    //Breakable wall physics
 				//Set the angle for the pieces
-				var angle	= darctan2(angleX, curY);
 				var angle2	= 0;
 				if (abs(curX) > 8.0) {
 					if (curX + startX >= startX)
@@ -75,7 +77,6 @@
 				case "Floor/Bounce":
 				case "Floor/No-Bounce":
 				case "Ceiling":
-					var angle		= darctan2(angleX, curY);
 					var velocity	= (abs(curX) + 2.0 * abs(curY)) / 4.0;
 					
 					// TODO: Check this

--- a/objects/obj_breakable_tile/Destroy_0.gml
+++ b/objects/obj_breakable_tile/Destroy_0.gml
@@ -19,18 +19,17 @@
 	//Play sound
 	sound_play(sfx_break1);
 
+	//Get breaking positions for wall and floor
+	var breakWallX = dir == 1 ? bbox_right : x;
+	var breakFloorX = x + (sprite_width / 2);
+	var breakWallY = y + (sprite_height / 2);
+	var breakFloorY = bbox_bottom;
+
 	//Get positions
-	var startX	= dir == 1 ? bbox_right : x;
-	var startY	= y + (sprite_height / 2);
+	var startX	= (breakable_type != "Wall") ? breakFloorX : breakWallX;
+	var startY	= (breakable_type != "Wall") ? breakFloorY : breakWallY;
 	var endX	= x + 8;
 	var endY	= y + 8;
-		
-	//Get position only for the breakable floor
-	if(breakable_type != "Wall")
-	{
-		startX	= x + (sprite_width / 2);
-		startY	= bbox_bottom;
-	}
 		
 	var curY = endY - startY;
 	for (var j = 0; j < size_y; j++) 

--- a/objects/obj_collapsing_tile/Other_10.gml
+++ b/objects/obj_collapsing_tile/Other_10.gml
@@ -64,23 +64,18 @@
 					break;
                     
 					//From the center
+					//and from both left and right
 					case "From the Center":
-						var tx = i - min_x;
-		                if (tx < size_x / 2)
-						{
-		                    tx = max_x - 1 - i;
-						}
-		                piece.delay = collapsing_speed * ((size_y + 2 * (tx) - (j - min_y))) - size_x * 3;
-					break;
-				    
-					//From both left and right
 					case "Both Left and Right":
 						var tx = i - min_x;
-		                if (tx > size_x / 2)
+		                var collapsing_point = collapsing_type == "From the Center" ? (tx < size_x / 2) : (tx > size_x / 2);
+						if (collapsing_point)
 						{
 		                    tx = max_x - 1 - i;
 						}
-		                piece.delay = collapsing_speed * ((size_y + 2 * (tx) - (j - min_y)));
+		                
+						var collapsing_point_delay = collapsing_type == "From the Center" ? (size_x * 3) : 0;
+						piece.delay = collapsing_speed * ((size_y + 2 * (tx) - (j - min_y))) - collapsing_point_delay;
 					break;
 				}
 	        }

--- a/objects/obj_dev/Step_1.gml
+++ b/objects/obj_dev/Step_1.gml
@@ -1,5 +1,5 @@
 /// @description Dev menu
-	room_speed = 60;
+	game_set_speed(60, gamespeed_fps);
 	
 	if(keyboard_check_pressed(vk_escape) && !instance_exists(obj_dev_menu) && !obj_shell.isOpen)
 	{
@@ -56,8 +56,8 @@
 			with(obj_bss_controller) bss_setup_character();
 		}
 		
-		if(keyboard_check(vk_f6)) room_speed = 5;
-		if(keyboard_check(vk_backspace)) room_speed = 240;
+		if(keyboard_check(vk_f6)) game_set_speed(5, gamespeed_fps);
+		if(keyboard_check(vk_backspace)) game_set_speed(240, gamespeed_fps);
 	
 		//Stop if player doesn't exist
 		if(!instance_exists(obj_player)) exit;

--- a/objects/obj_global/Other_75.gml
+++ b/objects/obj_global/Other_75.gml
@@ -1,0 +1,18 @@
+/// @description Find and set Event Type data
+
+	// Get the event type
+	switch ds_map_find_value(async_load, "event_type")
+	{
+	    // We found a gamepad!!!
+		case "gamepad discovered":
+			// Find the gamepad index and set it accordingly!
+	        input_controller_id = ds_map_find_value(async_load, "pad_index");
+	        break;
+			
+		// We lost a gamepad...
+	    case "gamepad lost":
+			// Find the newly reset gamepad index and get depressed from it.
+	        input_controller_id = ds_map_find_value(async_load, "pad_index");
+	        break;
+	}
+

--- a/objects/obj_global/obj_global.yy
+++ b/objects/obj_global/obj_global.yy
@@ -9,6 +9,7 @@
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":5,"eventType":7,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":4,"eventType":7,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":8,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
+    {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":75,"eventType":7,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
   ],
   "managed":true,
   "name":"obj_global",

--- a/scripts/game_macros/game_macros.gml
+++ b/scripts/game_macros/game_macros.gml
@@ -1,8 +1,7 @@
 function game_macros()
 {
 	// Developer mode macro
-	#macro DEVMODE false
-	#macro Dev:DEVMODE true
+	#macro DEVMODE (os_get_config() == "Dev")
 	
 	// Easy to access global variable macros
 	#macro WINDOW_WIDTH global.window_width

--- a/scripts/input_util/input_util.gml
+++ b/scripts/input_util/input_util.gml
@@ -25,6 +25,7 @@ function input_init()
 	input_data_controller = [];
 	input_data_controller_axis = [[]];
 	
+	input_controller_id = 0;
 	using_controller = false;
 }
 
@@ -41,17 +42,17 @@ function input_update()
 		
 		// Get the axis flip flag and set it's conditions
 		var axisFlip = input_data_controller_axis[i][1];
-		var axisCondition = axisFlip ? (gamepad_axis_value(0, input_data_controller_axis[i][0]) < -GAMEPAD_AXIS_DEADZONE) : (gamepad_axis_value(0, input_data_controller_axis[i][0]) > GAMEPAD_AXIS_DEADZONE);
+		var axisCondition = axisFlip ? (gamepad_axis_value(input_controller_id, input_data_controller_axis[i][0]) < -GAMEPAD_AXIS_DEADZONE) : (gamepad_axis_value(input_controller_id, input_data_controller_axis[i][0]) > GAMEPAD_AXIS_DEADZONE);
 		
 		// Is the input coming keyboard?
 		var isKeyboard = keyboard_check(input_data_keyboard[i]);
 		
 		// Is the input coming from the controller
-		var isController = axisCondition ||  gamepad_button_check(0, input_data_controller[i]);
+		var isController = axisCondition ||  gamepad_button_check(input_controller_id, input_data_controller[i]);
 		
 		// Decide if gamepad is currently being used or not
 		if(isKeyboard)
-			using_controller = false
+			using_controller = false;
 		else if(isController)
 			using_controller = true;
 		

--- a/scripts/player_visual_angle/player_visual_angle.gml
+++ b/scripts/player_visual_angle/player_visual_angle.gml
@@ -8,11 +8,13 @@ function player_visual_angle()
 		switch(global.rotation_type)
 		{
 			case 0:
+			case 2:
 				//Reset rotation target value
 				var rot = 0;
 			
 				//Change rotation value if its at specific angle
-				if(ground_angle > 33.75 && ground_angle < 333.50) 
+				if((global.rotation_type == 0 && ground_angle > 33.75 && ground_angle < 333.50)
+				|| (global.rotation_type == 2))
 				{
 					rot = ground_angle;
 				}
@@ -41,27 +43,6 @@ function player_visual_angle()
 					visual_angle = 0;	
 				}
 			break;
-			
-			case 2:
-				//Reset rotation target value
-				var rot = 0;
-			
-				//Change rotation value if its at specific angle
-				rot = ground_angle;
-				
-				//Rotate the player
-				if(abs(ground_speed) < 6)
-				{
-					visual_angle += (((rot - visual_angle + 540) mod 360)-180) / 4;
-				}
-				else
-				{
-					visual_angle += (((rot - visual_angle + 540) mod 360)-180) / 2;
-				}
-			
-				//Prevent angle from going into negative
-		        visual_angle = (visual_angle + 360) mod 360;
-			break;
 		}
 	}
 	else
@@ -83,12 +64,5 @@ function player_visual_angle()
 		visual_angle = 0;
 	}
 	
-	if(global.rotation_type == 1)
-	{
-		image_angle = round(visual_angle/45)*45;
-	}
-	else
-	{
-		image_angle = visual_angle;	
-	}
+	image_angle = (global.rotation_type == 1) ? round(visual_angle / 45) * 45 : visual_angle;
 }


### PR DESCRIPTION
This pull request aims to shut up Feather once and for all by cleaning up parts of the code that Feather sends warnings on, among other things.
In addition, some previously duplicated code has been merged into one, allowing for better improvements while, again, shutting Feather up, the only warnings it spits out now are all on the global score variable, an issue that would be resolved upon deprecation and removal of the built-in score variable or by changing the global variable name to something else.
In addition, this PR also restores the automatic assignment of the Gamepad Index from the old Input object *back* into the new Input system, allowing non-XInput controllers to be used again without the need to use external tools.